### PR TITLE
Fix next page path bug

### DIFF
--- a/gatsby/pagination/create-categories-pages.js
+++ b/gatsby/pagination/create-categories-pages.js
@@ -34,12 +34,12 @@ module.exports = async (graphql, actions) => {
           currentPage: i,
           postsLimit: postsPerPage,
           postsOffset: i * postsPerPage,
-          prevPagePath: i <= 1 ? categorySlug : `${categorySlug}/page/${i - 1}`,
-          nextPagePath: `/${categorySlug}/page/${i + 1}`,
-          hasPrevPage: i !== 0,
-          hasNextPage: i !== numPages - 1
-        }
-      });
+        prevPagePath: i <= 1 ? categorySlug : `${categorySlug}/page/${i - 1}`,
+        nextPagePath: `${categorySlug}/page/${i + 1}`,
+        hasPrevPage: i !== 0,
+        hasNextPage: i !== numPages - 1
+      }
+    });
     }
   });
 };


### PR DESCRIPTION
## Summary
- fix incorrect nextPagePath for category pagination

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn install` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_e_684019629140832f86ffae8645dd4655